### PR TITLE
Modify alert description for application status

### DIFF
--- a/admin/app/components/forms/application-cz-create-form.tsx
+++ b/admin/app/components/forms/application-cz-create-form.tsx
@@ -18,7 +18,7 @@ export function NoSemesterOpen() {
 		<Clock className="h-4 w-4" />
 		<AlertTitle>No semester open</AlertTitle>
 		<AlertDescription>
-			Sorry, applications for all semesters are closed now. 😕
+			Sorry, applications for all semesters are closed now. 😕 Registration will open on June 1, 2026.
 		</AlertDescription>
 	  </Alert>
 	)


### PR DESCRIPTION
This pull request updates the user-facing message in the `NoSemesterOpen` component to provide more specific information about when registration will reopen.